### PR TITLE
Require filefly-module from dmstr instead of hrzg

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "yiisoft/yii2": "*",
-    "hrzg/yii2-filefly-module" : "^0.5.0",
+    "dmstr/yii2-filefly-module" : "^0.5.0",
     "bower-asset/angular": "~1.5.0",
     "bower-asset/angular-sanitize": "~1.5.0",
     "bower-asset/angular-translate": "~2.9.1",


### PR DESCRIPTION
0.5.3 tag?