### PR TITLE
wrap angular-filemanager css in less scope

### DIFF
--- a/src/assets/AfmAsset.php
+++ b/src/assets/AfmAsset.php
@@ -33,7 +33,7 @@ class AfmAsset extends AssetBundle
      * @var array
      */
     public $css = [
-        'angular-filemanager.less',
+        'angular-filemanager-scoped.less',
         'angular-filemanager-custom.less'
     ];
 

--- a/src/assets/dist/angular-filemanager-scoped.less
+++ b/src/assets/dist/angular-filemanager-scoped.less
@@ -1,0 +1,4 @@
+// this is just a wrapper to scope angularFilemanager Styles to prevent side-effects
+angular-filemanager {
+  @import './angular-filemanager.less';
+}

--- a/src/assets/dist/angular-filemanager.less
+++ b/src/assets/dist/angular-filemanager.less
@@ -1,18 +1,20 @@
 @-webkit-keyframes fadeIn {
   0% {
-    opacity: 0
+    opacity: 0;
   }
+
   100% {
-    opacity: 1
+    opacity: 1;
   }
 }
 
 @keyframes fadeIn {
   0% {
-    opacity: 0
+    opacity: 0;
   }
+
   100% {
-    opacity: 1
+    opacity: 1;
   }
 }
 
@@ -20,12 +22,13 @@
   0% {
     opacity: 0;
     -webkit-transform: translate3d(0, -100%, 0);
-    transform: translate3d(0, -100%, 0)
+    transform: translate3d(0, -100%, 0);
   }
+
   100% {
     opacity: 1;
     -webkit-transform: none;
-    transform: none
+    transform: none;
   }
 }
 
@@ -33,72 +36,84 @@
   0% {
     opacity: 0;
     -webkit-transform: translate3d(0, -100%, 0);
-    transform: translate3d(0, -100%, 0)
+    transform: translate3d(0, -100%, 0);
   }
+
   100% {
     opacity: 1;
     -webkit-transform: none;
-    transform: none
+    transform: none;
   }
 }
 
 @keyframes rotate {
   100% {
-    transform: rotate(360deg)
+    transform: rotate(360deg);
   }
 }
 
 @-webkit-keyframes rotate {
   100% {
-    -webkit-transform: rotate(360deg)
+    -webkit-transform: rotate(360deg);
   }
 }
 
 @keyframes colors {
-  0%, 100% {
-    stroke: #4285F4
+  0% {
+    stroke: #4285F4;
   }
+
   25% {
-    stroke: #DE3E35
+    stroke: #DE3E35;
   }
+
   50% {
-    stroke: #F7C223
+    stroke: #F7C223;
   }
+
   75% {
-    stroke: #1B9A59
+    stroke: #1B9A59;
+  }
+
+  100% {
+    stroke: #4285F4;
   }
 }
 
 @keyframes dash {
   0% {
-    stroke-dasharray: 1, 150;
+    stroke-dasharray: 1,150;
     stroke-dashoffset: 0;
-    stroke: red
+    stroke: red;
   }
+
   50% {
-    stroke-dasharray: 90, 150;
+    stroke-dasharray: 90,150;
     stroke-dashoffset: -35;
-    stroke: #ff0
+    stroke: yellow;
   }
+
   100% {
-    stroke-dasharray: 90, 150;
+    stroke-dasharray: 90,150;
     stroke-dashoffset: -124;
-    stroke: green
+    stroke: green;
   }
 }
 
 @-webkit-keyframes dash {
   0% {
-    stroke-dasharray: 1, 150;
-    stroke-dashoffset: 0
+    stroke-dasharray: 1,150;
+    stroke-dashoffset: 0;
   }
+
   50% {
-    stroke-dasharray: 90, 150;
-    stroke-dashoffset: -35
+    stroke-dasharray: 90,150;
+    stroke-dashoffset: -35;
   }
+
   100% {
-    stroke-dasharray: 90, 150;
-    stroke-dashoffset: -124
+    stroke-dasharray: 90,150;
+    stroke-dashoffset: -124;
   }
 }
 
@@ -106,27 +121,28 @@
   -webkit-animation-duration: .7s;
   animation-duration: .7s;
   -webkit-animation-fill-mode: both;
-  animation-fill-mode: both
+  animation-fill-mode: both;
 }
 
-.animated.fast, .modal.animated {
+.modal.animated,
+.animated.fast {
   -webkit-animation-duration: .2s;
-  animation-duration: .2s
+  animation-duration: .2s;
 }
 
 .animated.slow {
   -webkit-animation-duration: 1.1s;
-  animation-duration: 1.1s
+  animation-duration: 1.1s;
 }
 
 .animated.fadeInDown {
   -webkit-animation-name: fadeInDown;
-  animation-name: fadeInDown
+  animation-name: fadeInDown;
 }
 
 .animated.fadeIn {
   -webkit-animation-name: fadeIn;
-  animation-name: fadeIn
+  animation-name: fadeIn;
 }
 
 .spinner-container {
@@ -134,764 +150,859 @@
   animation: rotate 2s linear infinite;
   z-index: 2;
   width: 65px;
-  height: 65px
+  height: 65px;
 }
 
 .spinner-container .path {
-  stroke-dasharray: 1, 150;
+  stroke-dasharray: 1,150;
   stroke-dashoffset: 0;
   stroke: #2196F3;
   stroke-linecap: round;
   -webkit-animation: dash 1.5s ease-in-out infinite, colors 5.6s ease-in-out infinite;
-  animation: dash 1.5s ease-in-out infinite, colors 5.6s ease-in-out infinite
+  animation: dash 1.5s ease-in-out infinite, colors 5.6s ease-in-out infinite;
+}
+.modal {
+  word-wrap: break-word;
 }
 
-angular-filemanager {
+.modal .label.error-msg {
+  display: block;
+  font-size: 12px;
+  margin-top: 5px;
+  padding: 0;
+  padding: 5px;
+  margin-top: 10px;
+  text-align: left;
+}
 
-  .modal {
-    word-wrap: break-word
+.modal .label.error-msg > span {
+  white-space: pre-wrap;
+}
+
+.modal .breadcrumb {
+  margin: 0;
+  background: #00bcd4;
+  font-size: 16px;
+  max-height: inherit;
+  padding: 0 10px;
+  margin-bottom: 5px;
+}
+
+.modal-fullscreen .modal-dialog,
+.modal-fullscreen .modal-content {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.modal-fullscreen .modal-dialog {
+  margin: 0;
+  width: 100%;
+}
+
+.modal-fullscreen .modal-content {
+  border: none;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  -webkit-box-shadow: inherit;
+  -moz-box-shadow: inherit;
+  -o-box-shadow: inherit;
+  box-shadow: inherit;
+}
+
+.modal-fullscreen textarea.code {
+  min-height: 450px;
+}
+
+.modal img.preview {
+  max-width: 100%;
+  max-height: 640px;
+  border-radius: 3px;
+}
+
+.modal img.preview.loading {
+  width: 100%;
+  height: 1px;
+  opacity: 0;
+}
+
+
+.modal .modal-content {
+  border-radius: 10px 10px 4px 4px;
+}
+
+.modal .modal-header {
+  border-radius: 4px 4px 0 0;
+  background: #2196F3;
+  padding: 1.3em;
+}
+
+.modal .modal-header .modal-title {
+  font-size: 20px;
+  line-height: 100%;
+  color: #D4E5F5;
+  margin: 0;
+}
+
+.modal .modal-header .close {
+  opacity: 1;
+  color: #D4E5F5;
+}
+
+.modal .modal-header .close.fullscreen {
+  font-size: 14px;
+  position: relative;
+  top: 4px;
+  margin-right: .8em;
+}
+body {
+  font-size: 14px;
+  height: 100vh;
+}
+
+*,
+*:focus {
+  outline: 0!important;
+}
+
+.navbar {
+  min-height: 32px;
+  margin-bottom: 0;
+  border: 0;
+  border-radius: 0;
+  color: #fff;
+}
+
+.navbar .navbar-collapse {
+  overflow: visible;
+  padding: 0;
+}
+
+.navbar .navbar-toggle {
+  padding: 5px 10px;
+}
+
+.navbar .navbar-brand {
+  font-size: inherit;
+  height: 55px;
+  line-height: 100%;
+}
+
+.btn.btn-default {
+  color: #444;
+  background-color: #FAFAFA;
+}
+
+.btn {
+  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .26);
+  font-weight: 500;
+  letter-spacing: .01em;
+  border: none;
+}
+
+textarea.code {
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-size: 13px;
+  min-height: 250px;
+  resize: vertical;
+  color: #000;
+}
+
+.sub-header {
+  padding-bottom: 10px;
+  border-bottom: 1px solid #eee;
+}
+
+.sidebar {
+  display: none;
+  background: #fafafa;
+  margin-top: 2px;
+  padding: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  border-right: 1px solid #eee;
+}
+
+.btn-go-back {
+  margin-top: -5px;
+}
+
+.nav-sidebar {
+  margin-right: -21px;
+  margin-bottom: 20px;
+  margin-left: -20px;
+}
+
+
+.nav-sidebar > li > a {
+  color: #7a7a7a;
+  padding: 7px 0 7px 16px;
+}
+
+
+.nav-sidebar> li > a:hover,
+.nav-sidebar> li > a:focus {
+  background: none;
+  color: #1378b9;
+}
+
+.nav-sidebar > li.active > a {
+  color: #2196F3;
+}
+
+
+.main {
+  padding: 0;
+}
+
+.main .page-header {
+  margin-top: 0;
+}
+
+.file-tree ul.nav.nav-sidebar {
+  margin: 0;
+  padding: 0;
+  padding-left: 12px;
+}
+
+.file-tree ul.nav.nav-sidebar:first-child {
+  padding-left: 0;
+}
+
+.file-tree ul.nav.nav-sidebar.file-tree-root > li {
+  border-left: none;
+  padding-left: 0px;
+}
+
+.table td {
+  vertical-align: middle;
+}
+
+#context-menu {
+  position: absolute;
+  display: none;
+  z-index: 9999;
+}
+
+.iconset {
+  padding: 10px;
+}
+
+.col-120 {
+  width: 100px;
+  max-height: 100px;
+  float: left;
+  margin-bottom: 9px;
+  margin-right: 9px;
+}
+
+.col-120.preview {
+  max-height: unset;
+  height: 120px;
+}
+
+.col-120:last-child {
+  margin-right: 0;
+}
+
+.noselect {
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none;   /* Chrome/Safari/Opera */
+  -khtml-user-select: none;    /* Konqueror */
+  -moz-user-select: none;      /* Firefox */
+  -ms-user-select: none;       /* IE/Edge */
+  user-select: none;           /* non-prefixed version, currently */
+}
+
+.iconset .thumbnail {
+  border-radius: 0;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  padding: 10px 0;
+  border: none;
+  background: none;
+}
+
+.iconset .preview .thumbnail {
+  height: 100px;
+  position: relative;
+}
+.iconset .preview .thumbnail .item-name {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+}
+
+.iconset .preview .thumbnail .item-icon i {
+  vertical-align: middle;
+}
+
+.iconset .thumbnail .image-preview-thumbnail img {
+  max-width: 100%;
+  max-height: 70px;
+}
+
+.table-files .selected,
+.iconset .thumbnail.selected {
+  background: #2196F3;
+}
+.iconset .preview .thumbnail.selected {
+  background: none;
+  color: #000;
+  border: 1px solid #2196F3;
+}
+
+.iconset .thumbnail.selected,
+.table-files .selected td,
+.table-files .selected td a {
+  color:#fff;
+}
+
+.iconset .thumbnail .item-icon {
+  font-size: 32px;
+}
+
+.detail-sources {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-wrap: break-word;
+}
+
+.dropdown-menu {
+  font-size: 14px;
+}
+
+.dropdown-menu > li > a {
+  padding: 6px 20px;
+}
+
+.dropdown-menu > li > a > i {
+  margin-right: 4px;
+}
+
+.dropdown-menu.dropdown-right-click {
+  display: block;
+  position: static;
+  margin-bottom: 5px;
+}
+
+.dropdown-menu.dropdown-right-click .divider {
+  margin: 3px 0;
+}
+
+.upload-dragover .main {
+  opacity: .4;
+}
+
+.upload-dragover:before {
+  content: "\e198";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 100;
+  color: #2196F3;
+  font-size: 8em;
+  font-family: 'Glyphicons Halflings';
+}
+
+.upload-list {
+  margin-top: 20px;
+}
+
+.spinner-wrapper {
+  margin: 0 auto;
+  text-align: center;
+  margin-top: 8%;
+}
+
+a:hover,
+a:active,
+a:focus,
+table th > a:hover,
+table th > a:active,
+table th > a:focus {
+  text-decoration: none;
+}
+
+.sortorder:after {
+  color: #2196f3;
+  content: '\25bc';
+}
+
+.sortorder.reverse:after {
+  color: #2196f3;
+  content: '\25b2';
+}
+
+[ng\:cloak], [ng-cloak],
+[data-ng-cloak], [x-ng-cloak],
+.ng-cloak, .x-ng-cloak {
+  display: none !important;
+}
+
+.mr2 {
+  margin-right: 2px;
+}
+
+.mr5 {
+  margin-right: 5px;
+}
+
+.mt10 {
+  margin-top: 10px;
+}
+
+.mb0 {
+  margin-bottom: 0;
+}
+
+.pointer {
+  cursor: pointer;
+}
+
+.block {
+  display: block;
+}
+
+.ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bold {
+  font-weight: bold;
+}
+
+.main {
+  overflow-y: auto;
+}
+
+@media (min-width: 768px) {
+  .main {
+    padding-right: 0;
+    padding-left: 0;
   }
 
-  .modal .label.error-msg {
-    display: block;
-    font-size: 12px;
-    padding: 5px;
-    margin-top: 10px;
-    text-align: left
+  /* The view should fill all available vertical space */
+  angular-filemanager > div,.row,.main,.sidebar {
+    height: 100%;
   }
 
-  .modal .label.error-msg > span {
-    white-space: pre-wrap
-  }
-
-  .modal .breadcrumb {
-    margin: 0 0 5px;
-    background: #00bcd4;
-    font-size: 16px;
-    max-height: inherit;
-    padding: 0 10px
-  }
-
-  .modal-fullscreen .modal-content, .modal-fullscreen .modal-dialog {
-    bottom: 0;
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0
-  }
-
-  .modal-fullscreen .modal-dialog {
-    margin: 0;
-    width: 100%
-  }
-
-  .modal-fullscreen .modal-content {
-    border: none;
-    -moz-border-radius: 0;
-    border-radius: 0;
-    -webkit-box-shadow: inherit;
-    -moz-box-shadow: inherit;
-    -o-box-shadow: inherit;
-    box-shadow: inherit
-  }
-
-  .modal-fullscreen textarea.code {
-    min-height: 450px
-  }
-
-  .modal img.preview {
-    max-width: 100%;
-    max-height: 640px;
-    border-radius: 3px
-  }
-
-  .modal img.preview.loading {
-    width: 100%;
-    height: 1px;
-    opacity: 0
-  }
-
-  .modal .modal-content {
-    border-radius: 10px 10px 4px 4px
-  }
-
-  .modal .modal-header {
-    border-radius: 4px 4px 0 0;
-    background: #2196F3;
-    padding: 1.3em
-  }
-
-  .modal .modal-header .modal-title {
-    font-size: 20px;
-    line-height: 100%;
-    color: #D4E5F5;
-    margin: 0
-  }
-
-  .modal .modal-header .close {
-    opacity: 1;
-    color: #D4E5F5
-  }
-
-  .modal .modal-header .close.fullscreen {
-    font-size: 14px;
-    position: relative;
-    top: 4px;
-    margin-right: .8em
-  }
-
-  .detail-sources, .ellipsis {
-    text-overflow: ellipsis;
-    overflow: hidden
-  }
-
-  body {
-    font-size: 14px;
-    height: 100vh
-  }
-
-  *, :focus {
-    outline: 0 !important
-  }
-
-  .navbar {
-    min-height: 32px;
-    margin-bottom: 0;
-    border: 0;
-    border-radius: 0;
-    color: #fff
-  }
-
-  .navbar .navbar-collapse {
-    overflow: visible;
-    padding: 0
-  }
-
-  .navbar .navbar-toggle {
-    padding: 5px 10px
-  }
-
-  .navbar .navbar-brand {
-    font-size: inherit;
-    height: 55px;
-    line-height: 100%
-  }
-
-  .btn.btn-default {
-    color: #444;
-    background-color: #FAFAFA
-  }
-
-  .btn {
-    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .26);
-    font-weight: 500;
-    letter-spacing: .01em;
-    border: none
-  }
-
-  textarea.code {
-    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-    font-size: 13px;
-    min-height: 250px;
-    resize: vertical;
-    color: #000
-  }
-
-  .sub-header {
-    padding-bottom: 10px;
-    border-bottom: 1px solid #eee
+  .container-fluid {
+    height: -webkit-calc(100% - 58px);
+    height: -moz-calc(100% - 58px);
+    height: calc(100% - 58px);
   }
 
   .sidebar {
-    display: none;
-    background: #fafafa;
-    margin-top: 2px;
-    padding: 0;
-    overflow-x: hidden;
-    overflow-y: auto;
-    border-right: 1px solid #eee
-  }
-
-  .btn-go-back {
-    margin-top: -5px
-  }
-
-  .nav-sidebar {
-    margin-right: -21px;
-    margin-bottom: 20px;
-    margin-left: -20px
-  }
-
-  .nav-sidebar > li > a {
-    color: #7a7a7a;
-    padding: 7px 0 7px 16px
-  }
-
-  .nav-sidebar > li > a:focus, .nav-sidebar > li > a:hover {
-    background: 0 0;
-    color: #1378b9
-  }
-
-  .nav-sidebar > li.active > a {
-    color: #2196F3
-  }
-
-  .main {
-    padding: 0
-  }
-
-  .main .page-header {
-    margin-top: 0
-  }
-
-  .file-tree ul.nav.nav-sidebar {
-    margin: 0;
-    padding: 0 0 0 12px
-  }
-
-  .file-tree ul.nav.nav-sidebar:first-child {
-    padding-left: 0
-  }
-
-  .file-tree ul.nav.nav-sidebar.file-tree-root > li {
-    border-left: none;
-    padding-left: 0
-  }
-
-  .table td {
-    vertical-align: middle
-  }
-
-  #context-menu {
-    position: absolute;
-    display: none;
-    z-index: 9999
-  }
-
-  .iconset {
-    padding: 10px
-  }
-
-  .col-120 {
-    width: 100px;
-    max-height: 100px;
-    float: left;
-    margin-bottom: 9px;
-    margin-right: 9px
-  }
-
-  .col-120:last-child {
-    margin-right: 0
-  }
-
-  .noselect {
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none
-  }
-
-  .iconset .thumbnail {
-    border-radius: 0;
-    overflow: hidden;
-    margin: 0;
-    padding: 10px 0;
-    border: none;
-    background: 0 0
-  }
-
-  .iconset .thumbnail .image-preview-thumbnail {
-    height: 85px;
-  }
-
-  .iconset .thumbnail .image-preview-thumbnail img {
-    max-width: 100%
-  }
-
-  .iconset .thumbnail.selected, .table-files .selected {
-    background: #2196F3
-  }
-
-  .iconset .thumbnail.selected, .table-files .selected td, .table-files .selected td a {
-    color: #fff
-  }
-
-  .iconset .thumbnail .item-icon {
-    font-size: 32px
-  }
-
-  .detail-sources {
-    word-wrap: break-word
-  }
-
-  .dropdown-menu {
-    font-size: 14px
-  }
-
-  .dropdown-menu > li > a {
-    padding: 6px 20px
-  }
-
-  .dropdown-menu > li > a > i {
-    margin-right: 4px
-  }
-
-  .dropdown-menu.dropdown-right-click {
     display: block;
-    position: static;
-    margin-bottom: 5px
   }
-
-  .dropdown-menu.dropdown-right-click .divider {
-    margin: 3px 0
-  }
-
-  .upload-dragover .main {
-    opacity: .4
-  }
-
-  .upload-dragover:before {
-    content: "\e198";
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    z-index: 100;
-    color: #2196F3;
-    font-size: 8em;
-    font-family: 'Glyphicons Halflings'
-  }
-
-  .upload-list {
-    margin-top: 20px
-  }
-
-  .spinner-wrapper {
-    margin: 8% auto 0;
-    text-align: center
-  }
-
-  a:active, a:focus, a:hover, table th > a:active, table th > a:focus, table th > a:hover {
-    text-decoration: none
-  }
-
-  .sortorder:after {
-    color: #2196f3;
-    content: '\25bc'
-  }
-
-  .sortorder.reverse:after {
-    color: #2196f3;
-    content: '\25b2'
-  }
-
-  .ng-cloak, .x-ng-cloak, [data-ng-cloak], [ng-cloak], [ng\:cloak], [x-ng-cloak] {
-    display: none !important
-  }
-
-  .mr2 {
-    margin-right: 2px
-  }
-
-  .mr5 {
-    margin-right: 5px
-  }
-
-  .mt10 {
-    margin-top: 10px
-  }
-
-  .mb0 {
-    margin-bottom: 0
-  }
-
-  .pointer {
-    cursor: pointer
-  }
-
-  .block {
-    display: block
-  }
-
-  .ellipsis {
-    white-space: nowrap
-  }
-
-  .bold {
-    font-weight: 700
-  }
-
-  .main {
-    overflow-y: auto
-  }
-
-  @media (min-width: 768px) {
-    .main {
-      padding-right: 0;
-      padding-left: 0
-    }
-
-    .main, .row, .sidebar, angular-filemanager > div {
-      height: 100%
-    }
-
-    .container-fluid {
-      height: -webkit-calc(100% - 58px);
-      height: -moz-calc(100% - 58px);
-      height: calc(100% - 58px)
-    }
-
-    .sidebar {
-      display: block
-    }
-  }
-
-  .selected-file-details {
-    padding-left: 20px
-  }
-
-  .item-extension::after {
-    font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    content: attr(data-ext);
-    left: 4px;
-    position: absolute;
-    color: #fff;
-    font-size: 9px;
-    text-transform: uppercase;
-    top: 21px
-  }
-
-  .selected .item-extension::after {
-    color: #2196F3
-  }
-
-  .form-control.search-input {
-    max-width: 20em;
-    display: inline
-  }
-
-  .like-code {
-    display: inline
-  }
-
-  .point {
-    margin-right: 8px;
-    font-size: 10px
-  }
-
-  .navbar .btn.btn-flat {
-    padding: 2px;
-    width: 32px;
-    height: 30px;
-    margin-left: 5px
-  }
-
-  .navbar-inverse .navbar-toggle .icon-bar {
-    background: #fff
-  }
-
-  .navbar-inverse .navbar-form input[type=text] {
-    color: #7a7a7a;
-    box-shadow: none;
-    margin: 0 10px
-  }
-
-  .navbar .navbar-form {
-    border-bottom: none;
-    border-top: none;
-    box-shadow: none;
-    padding: 0;
-    margin: 12px 0
-  }
-
-  .breadcrumb {
-    background: 0 0;
-    padding: 0;
-    font-size: 17px;
-    margin: 12px 0;
-    overflow: hidden;
-    max-height: 30px
-  }
-
-  .breadcrumb a, .breadcrumb > .active {
-    color: #fff
-  }
-
-  .breadcrumb > li + li:before {
-    font-family: 'Glyphicons Halflings';
-    content: "\e080";
-    font-size: 12px;
-    color: #fff
-  }
-
-  .scrollable-menu {
-    height: auto;
-    max-height: 200px;
-    overflow-x: hidden
-  }
-
-  .btn.btn-flat {
-    background: 0 0;
-    color: #fff
-  }
-
-  .btn-group.open > .btn-flat, .btn.btn-flat, .btn.btn-flat:active {
-    box-shadow: none
-  }
-
-  .btn.btn-flat > i {
-    font-size: 18px;
-    width: 18px;
-    height: 18px;
-    line-height: 100%
-  }
-
-  .multiSelect .acol, .multiSelect .caret, .multiSelect .inlineBlock, .multiSelect > button {
-    display: inline-block
-  }
-
-  .multiSelect .vertical {
-    float: none
-  }
-
-  .multiSelect .horizontal:not(.multiSelectGroup) {
-    float: left
-  }
-
-  .multiSelect .line {
-    padding: 2px 0 4px;
-    max-height: 30px;
-    overflow: hidden;
-    box-sizing: content-box
-  }
-
-  .multiSelect .acol {
-    min-width: 12px
-  }
-
-  .multiSelect > button {
-    position: relative;
-    text-align: center;
-    cursor: pointer;
-    border: 1px solid #c6c6c6;
-    padding: 1px 8px;
-    font-size: 14px;
-    min-height: 38px !important;
-    border-radius: 4px;
-    color: #555;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    -o-user-select: none;
-    user-select: none;
-    white-space: normal;
-    background-color: #fff;
-    background-image: linear-gradient(#fff, #f7f7f7)
-  }
-
-  .multiSelect > button:hover {
-    background-image: linear-gradient(#fff, #e9e9e9)
-  }
-
-  .multiSelect > button:disabled {
-    background-image: linear-gradient(#fff, #fff);
-    border: 1px solid #ddd;
-    color: #999
-  }
-
-  .multiSelect .buttonClicked {
-    box-shadow: 0 2px 5px rgba(0, 0, 0, .15) inset, 0 1px 2px rgba(0, 0, 0, .05)
-  }
-
-  .multiSelect .buttonLabel {
-    display: inline-block;
-    padding: 5px 0
-  }
-
-  .multiSelect .caret {
-    width: 0;
-    height: 0;
-    margin: 0 0 1px 12px !important;
-    vertical-align: middle;
-    border-top: 4px solid #333;
-    border-right: 4px solid transparent;
-    border-left: 4px solid transparent;
-    border-bottom: 0 dotted
-  }
-
-  .multiSelect .checkboxLayer {
-    background-color: #fff;
-    position: absolute;
-    z-index: 999;
-    border: 1px solid rgba(0, 0, 0, .15);
-    border-radius: 4px;
-    -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
-    box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
-    min-width: 278px;
-    display: none !important
-  }
-
-  .multiSelect .clearButton, .multiSelect .helperButton {
-    display: inline;
-    text-align: center;
-    font-size: 13px;
-    color: #666;
-    background-color: #f1f1f1;
-    cursor: pointer
-  }
-
-  .multiSelect .helperContainer {
-    border-bottom: 1px solid #ddd;
-    padding: 8px 8px 0
-  }
-
-  .multiSelect .helperButton {
-    border: 1px solid #ccc;
-    height: 26px;
-    border-radius: 2px;
-    line-height: 1.6;
-    margin: 0 0 8px
-  }
-
-  .multiSelect .helperButton.reset {
-    float: right
-  }
-
-  .multiSelect .helperButton:not( .reset ) {
-    margin-right: 4px
-  }
-
-  .multiSelect .clearButton {
-    position: absolute;
-    border: 1px solid #ccc;
-    height: 22px;
-    width: 22px;
-    border-radius: 2px;
-    line-height: 1.4;
-    right: 2px;
-    top: 4px
-  }
-
-  .multiSelect .inputFilter {
-    border-radius: 2px;
-    border: 1px solid #ccc;
-    height: 26px;
-    font-size: 14px;
-    width: 100%;
-    padding-left: 7px;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    color: #888;
-    margin: 0 0 8px;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075)
-  }
-
-  .multiSelect .clearButton:hover, .multiSelect .helperButton:hover {
-    border: 1px solid #ccc;
-    color: #999;
-    background-color: #f4f4f4
-  }
-
-  .multiSelect .helperButton:disabled {
-    color: #ccc;
-    border: 1px solid #ddd
-  }
-
-  .multiSelect .clearButton:focus, .multiSelect .helperButton:focus, .multiSelect .inputFilter:focus {
-    border: 1px solid #66AFE9 !important;
-    outline: 0;
-    -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, .065), 0 0 5px rgba(102, 175, 233, .6) !important;
-    box-shadow: inset 0 0 1px rgba(0, 0, 0, .065), 0 0 5px rgba(102, 175, 233, .6) !important
-  }
-
-  .multiSelect .checkBoxContainer {
-    display: block;
-    padding: 8px;
-    overflow: hidden
-  }
-
-  .multiSelect .show {
-    display: block !important
-  }
-
-  .multiSelect .multiSelectItem {
-    display: block;
-    padding: 3px;
-    color: #444;
-    white-space: nowrap;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    -o-user-select: none;
-    user-select: none;
-    border: 1px solid transparent;
-    position: relative;
-    min-width: 278px;
-    min-height: 32px
-  }
-
-  .multiSelect .multiSelectItem:not(.multiSelectGroup).selected {
-    background-image: linear-gradient(#e9e9e9, #f1f1f1);
-    color: #555;
-    cursor: pointer;
-    border-top: 1px solid #e4e4e4;
-    border-left: 1px solid #e4e4e4;
-    border-right: 1px solid #d9d9d9
-  }
-
-  .multiSelect .multiSelectItem .acol label {
-    display: inline-block;
-    padding-right: 30px;
-    margin: 0;
-    font-weight: 400;
-    line-height: normal
-  }
-
-  .multiSelect .multiSelectFocus, .multiSelect .multiSelectGroup:hover, .multiSelect .multiSelectItem:hover {
-    background-image: linear-gradient(#c1c1c1, #999) !important;
-    color: #fff !important;
-    cursor: pointer;
-    border: 1px solid #ccc !important
-  }
-
-  .multiSelect .multiSelectGroup span:hover, .multiSelect .multiSelectItem span:hover {
-    cursor: pointer
-  }
-
-  .multiSelect .multiSelectGroup {
-    display: block;
-    clear: both
-  }
-
-  .multiSelect .tickMark {
-    display: inline-block;
-    position: absolute;
-    right: 10px;
-    top: 7px;
-    font-size: 10px
-  }
-
-  .multiSelect .checkbox {
-    color: #ddd !important;
-    position: absolute;
-    left: -9999px;
-    cursor: pointer
-  }
-
-  .multiSelect .disabled, .multiSelect .disabled label input:hover ~ span, .multiSelect .disabled:hover {
-    color: #c4c4c4 !important;
-    cursor: not-allowed !important
-  }
-
-  .multiSelect img {
-    vertical-align: middle;
-    margin-bottom: 0;
-    max-height: 22px;
-    max-width: 22px
-  }
-
+}
+
+.selected-file-details {
+  padding-left: 20px;
+}
+
+.item-extension::after {
+  font-family: "Roboto","Helvetica Neue",Helvetica,Arial,sans-serif;
+  content: attr(data-ext);
+  left: 4px;
+  position: absolute;
+  color: #fff;
+  font-size: 9px;
+  text-transform: uppercase;
+  top: 21px;
+}
+
+.selected .item-extension::after {
+  color: #2196F3;
+}
+
+.form-control.search-input {
+  max-width: 20em;
+  display: inline;
+}
+
+.like-code {
+  display: inline;
+}
+
+.point {
+  margin-right: 8px;
+  font-size: 10px;
+}
+
+.navbar .btn.btn-flat {
+  padding: 2px;
+  width: 32px;
+  height: 30px;
+  margin-left: 5px;
+}
+
+.navbar-inverse .navbar-toggle .icon-bar {
+  background: #fff;
+}
+
+.navbar-inverse .navbar-form input[type="text"] {
+  color: #7a7a7a;
+  box-shadow: none;
+  margin: 0 10px;
+}
+
+.navbar .navbar-form {
+  border-bottom: none;
+  border-top: none;
+  box-shadow: none;
+  padding: 0;
+  margin: 12px 0;
+}
+
+.breadcrumb {
+  background: none;
+  padding: 0;
+  font-size: 17px;
+  margin: 12px 0;
+  overflow: hidden;
+  max-height: 30px
+}
+
+.breadcrumb>.active,
+.breadcrumb a {
+  color: #fff;
+}
+
+.breadcrumb>li+li:before {
+  font-family: 'Glyphicons Halflings';
+  content: "\e080";
+  font-size: 12px;
+  color: #fff;
+}
+
+.scrollable-menu {
+  height: auto;
+  max-height: 200px;
+  overflow-x: hidden;
+}
+
+.btn.btn-flat {
+  background: none;
+  color: #fff;
+}
+
+.btn-group.open > .btn-flat,
+.btn.btn-flat,
+.btn.btn-flat:active {
+  box-shadow: none;
+}
+
+.btn.btn-flat > i {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  line-height: 100%;
+}
+
+/*
+ * Don't modify things marked with ! - unless you know what you're doing
+ */
+
+/* ! vertical layout */
+.multiSelect .vertical {
+  float: none;
+}
+
+/* ! horizontal layout */
+.multiSelect .horizontal:not(.multiSelectGroup) {
+  float: left;
+}
+
+/* ! create a "row" */
+.multiSelect .line {
+  padding:  2px 0px 4px 0px;
+  max-height: 30px;
+  overflow: hidden;
+  box-sizing: content-box;
+}
+
+/* ! create a "column" */
+.multiSelect .acol {
+  display: inline-block;
+  min-width: 12px;
+}
+
+/* ! */
+.multiSelect .inlineBlock {
+  display: inline-block;
+}
+
+/* the multiselect button */
+.multiSelect > button {
+  display: inline-block;
+  position: relative;
+  text-align: center;
+  cursor: pointer;
+  border: 1px solid #c6c6c6;
+  padding: 1px 8px 1px 8px;
+  font-size: 14px;
+  min-height : 38px !important;
+  border-radius: 4px;
+  color: #555;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+  white-space:normal;
+  background-color: #fff;
+  background-image: linear-gradient(#fff, #f7f7f7);
+}
+
+/* button: hover */
+.multiSelect > button:hover {
+  background-image: linear-gradient(#fff, #e9e9e9);
+}
+
+/* button: disabled */
+.multiSelect > button:disabled {
+  background-image: linear-gradient(#fff, #fff);
+  border: 1px solid #ddd;
+  color: #999;
+}
+
+/* button: clicked */
+.multiSelect .buttonClicked {
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15) inset, 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+/* labels on the button */
+.multiSelect .buttonLabel {
+  display: inline-block;
+  padding: 5px 0px 5px 0px;
+}
+
+/* downward pointing arrow */
+.multiSelect .caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin: 0px 0px 1px 12px  !important;
+  vertical-align: middle;
+  border-top: 4px solid #333;
+  border-right: 4px solid transparent;
+  border-left: 4px solid transparent;
+  border-bottom: 0 dotted;
+}
+
+/* the main checkboxes and helper layer */
+.multiSelect .checkboxLayer {
+  background-color: #fff;
+  position: absolute;
+  z-index: 999;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  min-width:278px;
+  display: none !important;
+}
+
+/* container of helper elements */
+.multiSelect .helperContainer {
+  border-bottom: 1px solid #ddd;
+  padding: 8px 8px 0px 8px;
+}
+
+/* helper buttons (select all, none, reset); */
+.multiSelect .helperButton {
+  display: inline;
+  text-align: center;
+  cursor: pointer;
+  border: 1px solid #ccc;
+  height: 26px;
+  font-size: 13px;
+  border-radius: 2px;
+  color: #666;
+  background-color: #f1f1f1;
+  line-height: 1.6;
+  margin: 0px 0px 8px 0px;
+}
+
+.multiSelect .helperButton.reset{
+  float: right;
+}
+
+.multiSelect .helperButton:not( .reset ) {
+  margin-right: 4px;
+}
+
+/* clear button */
+.multiSelect .clearButton {
+  position: absolute;
+  display: inline;
+  text-align: center;
+  cursor: pointer;
+  border: 1px solid #ccc;
+  height: 22px;
+  width: 22px;
+  font-size: 13px;
+  border-radius: 2px;
+  color: #666;
+  background-color: #f1f1f1;
+  line-height: 1.4;
+  right : 2px;
+  top: 4px;
+}
+
+/* filter */
+.multiSelect .inputFilter {
+  border-radius: 2px;
+  border: 1px solid #ccc;
+  height: 26px;
+  font-size: 14px;
+  width:100%;
+  padding-left:7px;
+  -webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
+  -moz-box-sizing: border-box;    /* Firefox, other Gecko */
+  box-sizing: border-box;         /* Opera/IE 8+ */
+  color: #888;
+  margin: 0px 0px 8px 0px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+}
+
+/* helper elements on hover & focus */
+.multiSelect .clearButton:hover,
+.multiSelect .helperButton:hover {
+  border: 1px solid #ccc;
+  color: #999;
+  background-color: #f4f4f4;
+}
+.multiSelect .helperButton:disabled {
+  color: #ccc;
+  border: 1px solid #ddd;
+}
+
+.multiSelect .clearButton:focus,
+.multiSelect .helperButton:focus,
+.multiSelect .inputFilter:focus {
+  border: 1px solid #66AFE9 !important;
+  outline: 0;
+  -webkit-box-shadow: inset 0 0 1px rgba(0,0,0,.065), 0 0 5px rgba(102, 175, 233, .6) !important;
+  box-shadow: inset 0 0 1px rgba(0,0,0,.065), 0 0 5px rgba(102, 175, 233, .6) !important;
+}
+
+/* container of multi select items */
+.multiSelect .checkBoxContainer {
+  display: block;
+  padding: 8px;
+  overflow: hidden;
+}
+
+/* ! to show / hide the checkbox layer above */
+.multiSelect .show {
+  display: block !important;
+}
+
+/* item labels */
+.multiSelect .multiSelectItem {
+  display: block;
+  padding: 3px;
+  color: #444;
+  white-space: nowrap;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+  border: 1px solid transparent;
+  position: relative;
+  min-width:278px;
+  min-height: 32px;
+}
+
+/* Styling on selected items */
+.multiSelect .multiSelectItem:not(.multiSelectGroup).selected
+{
+  background-image: linear-gradient( #e9e9e9, #f1f1f1 );
+  color: #555;
+  cursor: pointer;
+  border-top: 1px solid #e4e4e4;
+  border-left: 1px solid #e4e4e4;
+  border-right: 1px solid #d9d9d9;
+}
+
+.multiSelect .multiSelectItem .acol label {
+  display: inline-block;
+  padding-right: 30px;
+  margin: 0px;
+  font-weight: normal;
+  line-height: normal;
+}
+
+/* item labels focus on mouse hover */
+.multiSelect .multiSelectItem:hover,
+.multiSelect .multiSelectGroup:hover {
+  background-image: linear-gradient( #c1c1c1, #999 ) !important;
+  color: #fff !important;
+  cursor: pointer;
+  border: 1px solid #ccc !important;
+}
+
+/* item labels focus using keyboard */
+.multiSelect .multiSelectFocus {
+  background-image: linear-gradient( #c1c1c1, #999 ) !important;
+  color: #fff !important;
+  cursor: pointer;
+  border: 1px solid #ccc !important;
+}
+
+/* change mouse pointer into the pointing finger */
+.multiSelect .multiSelectItem span:hover,
+.multiSelect .multiSelectGroup span:hover
+{
+  cursor: pointer;
+}
+
+/* ! group labels */
+.multiSelect .multiSelectGroup {
+  display: block;
+  clear: both;
+}
+
+/* right-align the tick mark (&#10004;) */
+.multiSelect .tickMark {
+  display:inline-block;
+  position: absolute;
+  right: 10px;
+  top: 7px;
+  font-size: 10px;
+}
+
+/* hide the original HTML checkbox away */
+.multiSelect .checkbox {
+  color: #ddd !important;
+  position: absolute;
+  left: -9999px;
+  cursor: pointer;
+}
+
+/* checkboxes currently disabled */
+.multiSelect .disabled,
+.multiSelect .disabled:hover,
+.multiSelect .disabled label input:hover ~ span {
+  color: #c4c4c4 !important;
+  cursor: not-allowed !important;
+}
+
+/* If you use images in button / checkbox label, you might want to change the image style here. */
+.multiSelect img {
+  vertical-align: middle;
+  margin-bottom:0px;
+  max-height: 22px;
+  max-width:22px;
 }


### PR DESCRIPTION
This PR wrap the angular-filemanager.less (css) in an angular-filemanager less scope to prevent side-effects due to generic element styles from angular-filemanager css.
Reason why this is done via `@import`is, that we still want to overwrite the angular-filemanager.less from external build tool.